### PR TITLE
remove migrate script from heroku build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "start:dev": "concurrently \"npm run start:back\" \"npm run start:front\"",
     "build-css": "tachyons src/css/app.css > src/index.css --minify",
     "watch-css": "chokidar src/css/app.css -c 'npm run build-css'",
-    "migrate-spreadsheet": "node ./migrateSpreadsheet.js",
-    "heroku-postbuild": "npm install && npm install --only=dev --no-shrinkwrap && npm run build && npm run migrate-spreadsheet"
+    "heroku-postbuild": "npm install && npm install --only=dev --no-shrinkwrap && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previous build failed on heroku due to the migrateSpreadsheet script being refactored to be called on FE. 

We no longer need to run this script as part of deployment, so removing it. 